### PR TITLE
feat: add health check endpoint for load balancers

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,19 +1,35 @@
 const express = require('express');
 const path = require('path');
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.get('/api/hello', (req, res)=>{
-  res.json({message: 'Hello from demo-webapp backend'});
+/**
+ * Health check endpoint
+ * Used by load balancers and Kubernetes liveness/readiness probes
+ */
+app.get('/healthz', (req, res) => {
+  res.status(200).json({
+    status: 'ok',
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString()
+  });
 });
 
-if(process.env.NODE_ENV === 'production'){
+app.get('/api/hello', (req, res) => {
+  res.json({ message: 'Hello from demo-webapp backend' });
+});
+
+if (process.env.NODE_ENV === 'production') {
   app.use(express.static(path.join(__dirname, '..', 'frontend', 'build')));
-  app.get('*', (req,res)=>{
-    res.sendFile(path.join(__dirname, '..', 'frontend', 'build', 'index.html'));
+
+  app.get('*', (req, res) => {
+    res.sendFile(
+      path.join(__dirname, '..', 'frontend', 'build', 'index.html')
+    );
   });
 }
 
-app.listen(PORT, ()=>{
+app.listen(PORT, () => {
   console.log(`demo-webapp backend listening on ${PORT}`);
 });


### PR DESCRIPTION
This PR adds a `/healthz` endpoint to the backend to support health checks from load balancers and Kubernetes liveness/readiness probes.

The endpoint returns HTTP 200 along with a basic JSON status payload including:

* `status`
* `uptime`
* `timestamp`

### 📌 Endpoint

```
GET /healthz
```

Example response:

```json
{
  "status": "ok",
  "uptime": 123.456,
  "timestamp": "2026-02-17T10:15:30.000Z"
}
```

### 🎯 Why This Change?

* Enables Kubernetes `livenessProbe` and `readinessProbe`
* Supports cloud load balancer health checks
* Improves observability and operational reliability
* Lightweight and has no external dependencies

### 🧪 Testing

* Verified endpoint returns `200 OK`
* Confirmed JSON response structure
* Works in both development and production environments
